### PR TITLE
Keep text selection when modal invoked

### DIFF
--- a/src/bootstrap-wysihtml5.js
+++ b/src/bootstrap-wysihtml5.js
@@ -243,6 +243,7 @@
 
 			toolbar.find('a[data-wysihtml5-command=insertImage]').click(function() {
 				insertImageModal.modal('show');
+				return false;
 			});
 		},
 
@@ -283,6 +284,7 @@
 
 			toolbar.find('a[data-wysihtml5-command=createLink]').click(function() {
 				insertLinkModal.modal('show');
+				return false;
 			});
 		}
 	};


### PR DESCRIPTION
Right now clicking insertLink and insertImage buttons causes the text selection to be lost.  To prevent this I have added return false statements to the click event callbacks for these buttons.
