### PR TITLE
Stylesheet Option

### DIFF
--- a/readme.textile
+++ b/readme.textile
@@ -58,6 +58,14 @@ $('#some-textarea').wysihtml5({
 });
 </pre>
 
+It is possible to supply a number of stylesheets for inclusion in the editor `<iframe>`:
+
+<pre>
+$('#some-textarea').wysihtml5({
+	"stylesheets": ["/path/to/editor.css"]
+});
+</pre>
+
 Wysihtml5 exposes a "number of events":https://github.com/xing/wysihtml5/wiki/Events. You can hook into these events when initialising the editor:
 
 <pre>

--- a/src/bootstrap-wysihtml5.js
+++ b/src/bootstrap-wysihtml5.js
@@ -113,7 +113,8 @@
 					}
 				}
 			}
-		}
+		},
+		stylesheets: []
 	};
 
 	var Wysihtml5 = function(el, options) {
@@ -135,26 +136,32 @@
 	Wysihtml5.prototype = {
 		constructor: Wysihtml5,
 
-		createEditor: function(options) {
-			var parserRules = defaultOptions.parserRules; 
+    createEditor: function(options) {
+      var parserRules = defaultOptions.parserRules; 
+      var stylesheets = defaultOptions.stylesheets;
 
-			if(options && options.parserRules) {
-				parserRules = options.parserRules;
-			}
-				
-			var editor = new wysi.Editor(this.el.attr('id'), {
-	    		toolbar: this.toolbar.attr('id'),
-				parserRules: parserRules
-	  		});
+      if(options && options.parserRules) {
+        parserRules = options.parserRules;
+      }
 
-	  		if(options && options.events) {
-				for(var eventName in options.events) {
-					editor.on(eventName, options.events[eventName]);
-				}
-			}	
+      if (options && options.stylesheets) {
+        stylesheets = options.stylesheets;
+      }
 
-	  		return editor;
-		},
+      var editor = new wysi.Editor(this.el.attr('id'), {
+        toolbar: this.toolbar.attr('id'),
+        parserRules: parserRules,
+        stylesheets: stylesheets
+      });
+
+      if(options && options.events) {
+        for(var eventName in options.events) {
+          editor.on(eventName, options.events[eventName]);
+        }
+      }  
+
+      return editor;
+    },
 		
 		createToolbar: function(el, options) {
 			var self = this;


### PR DESCRIPTION
Passing an option like 

```
$('#textarea').wysihtml5({
  "stylesheets": ["/path/to/stylesheet/for/editor.css"]
});
```

will include the specified stylesheets in the editor's `<iframe>`.

This is a documented feature of `wysihtml5.js`, but hasn't been exposed through `bootstrap-wysihtml5` before.
