### PR TITLE
textarea and toolbar don't need ids

### DIFF
--- a/src/bootstrap-wysihtml5.js
+++ b/src/bootstrap-wysihtml5.js
@@ -148,8 +148,8 @@
         stylesheets = options.stylesheets;
       }
 
-      var editor = new wysi.Editor(this.el.attr('id'), {
-        toolbar: this.toolbar.attr('id'),
+      var editor = new wysi.Editor(this.el[0], {
+        toolbar: this.toolbar[0],
         parserRules: parserRules,
         stylesheets: stylesheets
       });
@@ -166,7 +166,6 @@
 		createToolbar: function(el, options) {
 			var self = this;
 			var toolbar = $("<ul/>", {
-				'id' : el.attr('id') + "-wysihtml5-toolbar",
 				'class' : "wysihtml5-toolbar",
 				'style': "display:none"
 			});


### PR DESCRIPTION
The current implementation forces users to set an id on the textarea which isn't necessary for wysihtml5.
