### PR TITLE
Added blockquote to the default set of tags allowed for wysihtml5 parser...

### DIFF
--- a/src/bootstrap-wysihtml5.js
+++ b/src/bootstrap-wysihtml5.js
@@ -86,6 +86,7 @@
                 "li": {},
                 "h1": {},
                 "h2": {},
+                "blockquote": {},
                 "u": 1,
                 "img": {
                     "check_attributes": {


### PR DESCRIPTION
This prevents indents from being deleted the moment the user enters html source mode. Paragraphs should also probably go in, but your UI doesn't generate paragraphs so I didn't add them.
