### PR TITLE
Font size text disappears after click in Firefox

### DIFF
--- a/src/bootstrap-wysihtml5.js
+++ b/src/bootstrap-wysihtml5.js
@@ -181,7 +181,8 @@
             }
 
             toolbar.find("a[data-wysihtml5-command='formatBlock']").click(function(e) {
-                var el = $(e.srcElement);
+                var target = e.target || e.srcElement;
+                var el = $(target);
                 self.toolbar.find('.current-font').text(el.html());
             });
 


### PR DESCRIPTION
In Firefox when you select the Normal Text button, and then choose a text size, the text beside the A image disappears. ie: You no longer see "Normal Text", "Heading 1", or "Heading 2".

This is because onClick the name is taken from the event.srcElement; however, this attribute doesn't exist in some browsers like Firefox. This fix adds a check and now works across more browsers.
