### PR TITLE
Update src/bootstrap-wysihtml5.js

### DIFF
--- a/src/bootstrap-wysihtml5.js
+++ b/src/bootstrap-wysihtml5.js
@@ -343,7 +343,7 @@
               var activeButton = $(this).hasClass("wysihtml5-command-active");
               
               if (!activeButton) {
-                insertLinkModal.modal('show');
+                insertLinkModal.append('body').modal('show');
                 insertLinkModal.on('click.dismiss.modal', '[data-dismiss="modal"]', function(e) {
         					e.stopPropagation();
         				});


### PR DESCRIPTION
When the wysihtml5 editor is in a div with absolute positioning and a large z-index, sometimes the overlay shows up _over_ the dialog box. Appending the dialog to the <body> solves this.
