### PR TITLE
Fix for the editor not being returned from the constructor

### DIFF
--- a/src/bootstrap-wysihtml5.js
+++ b/src/bootstrap-wysihtml5.js
@@ -314,16 +314,16 @@
         shallowExtend: function (options) {
             var settings = $.extend({}, $.fn.wysihtml5.defaultOptions, options || {});
             var that = this;
-            methods.bypassDefaults.apply(that, [settings]);
+            return methods.bypassDefaults.apply(that, [settings]);
         },
         deepExtend: function(options) {
             var settings = $.extend(true, {}, $.fn.wysihtml5.defaultOptions, options || {});
             var that = this;
-            methods.bypassDefaults.apply(that, [settings]);
+            return methods.bypassDefaults.apply(that, [settings]);
         },
         init: function(options) {
             var that = this;
-            methods.shallowExtend.apply(that, [options]);
+            return methods.shallowExtend.apply(that, [options]);
         }
     };
 


### PR DESCRIPTION
With the recent changes, the init functions do not return their values, which means that a call to elem.wysihtml5() will return undefined. This change just adds returns to the init functions.
