### PR TITLE
The word 'body' kept showing up in the insertLink modal

### DIFF
--- a/readme.textile
+++ b/readme.textile
@@ -135,6 +135,31 @@ $(this).wysihtml5('resetDefaults')
 
 Operations on the defaults are not thread-safe; if you're going to change the defaults, you probably want to do it only once, after you load the bootstrap-wysihtml plugin and before you start instantiating your editors.
 
+h3. Custom styles menu
+
+You can add custom styles (which wrap text with spans that have a class) using adding customStyles to your options.
+
+<pre>
+$(this).wysihtml5({customStyles : { my_style: 'My Style' }}) 
+</pre>
+
+will create a new item in the styles dropdown menu which reads "MyStyle".  If you highlight text and choose this style, the text will be wrapped with
+
+<pre>
+<span class="my_style"> the selected text </span>
+</pre>
+
+These custom styles will also be automatically added to the safe-class list in the parser.
+
+You can also remove default styles from this menu by including an array of styles you'd like to not be included.  The default styles are 'h1','h2','h3', and 'normal'.  
+
+<pre>
+$(this).wysihtml5({removeStyles : ['h2', 'h3']})
+</pre>
+
+will give you a styles menu that only includes 'h1' and 'normal'.
+
+
 h2. The underlying wysihtml5 object
 
 You can access the "wysihtml5 editor object":https://github.com/xing/wysihtml5 like this:

--- a/src/bootstrap-wysihtml5.js
+++ b/src/bootstrap-wysihtml5.js
@@ -287,7 +287,7 @@
                 var activeButton = $(this).hasClass("wysihtml5-command-active");
 
                 if (!activeButton) {
-                    insertLinkModal.append('body').modal('show');
+                    insertLinkModal.appendTo('body').modal('show');
                     insertLinkModal.on('click.dismiss.modal', '[data-dismiss="modal"]', function(e) {
                         e.stopPropagation();
                     });

--- a/test/editor_test.js
+++ b/test/editor_test.js
@@ -36,10 +36,13 @@ if (wysihtml5.browser.supported()) {
     getComposerElement: function() {
       return this.getIframeElement().contentWindow.document.body;
     },
-
     getIframeElement: function() {
       var iframes = document.querySelectorAll("iframe.wysihtml5-sandbox");
       return iframes[iframes.length - 1];
+    },
+    getToolbarElement: function() {
+      var toolbars = document.querySelectorAll(".wysihtml5-toolbar");
+      return toolbars[0];
     }
   });
 
@@ -113,6 +116,27 @@ if (wysihtml5.browser.supported()) {
       ok(wysihtml5.dom.hasClass(composerElement, name), "iFrame's body has adopted name as className");
       ok(wysihtml5.dom.hasClass(composerElement, "death-star"), "iFrame's body has adopted the textarea className");
       ok(!wysihtml5.dom.hasClass(textareaElement, name), "Textarea has not adopted name as className");
+      start();
+    });
+  });
+
+
+  asyncTest("Check the toolbar and customStyles", function() {
+    expect(4);
+
+    this.textareaElement.className = "death-star";
+
+    var that   = this;
+    var name   = "star-wars-input";
+    $(this.textareaElement).wysihtml5({ html: true, customStyles: { other: 'Other Style'}, removeStyles: [ 'h1' ] });
+    var editor = $(this.textareaElement).data('wysihtml5').editor;
+    var classes = $(this.textareaElement).data('wysihtml5').configuration.parserRules.classes
+    ok(classes.other === 1, 'custom classes were not added to the safe parse list');
+    editor.observe("load", function() {
+      var toolbar = that.getToolbarElement();
+      ok($(toolbar).find('ul.dropdown-menu a[data-wysihtml5-command=formatBlock]').length === 3, "toolbar includes all default styles that were not removed witgh removeStyles option");
+      ok($(toolbar).find('ul.dropdown-menu a[data-wysihtml5-command=customSpan]').length === 1 , "toolbar includes the custom styles");
+      ok(/Other Style/.test($(toolbar).find('ul.dropdown-menu a[data-wysihtml5-command=customSpan]').text()), "toolbar custom style title is not correct");
       start();
     });
   });


### PR DESCRIPTION
Instead of appending the word 'body' to the insertLinkModal, we should append the insertLinkModal to the body.

Tiny change.  I did not update tests since there were none around this functionality.
