### PR TITLE
Uncaught exception fix (InsertLink/Image)

### DIFF
--- a/src/bootstrap-wysihtml5.js
+++ b/src/bootstrap-wysihtml5.js
@@ -212,6 +212,7 @@
             var insertImage = function() {
                 var url = urlInput.val();
                 urlInput.val(initialValue);
+                self.editor.currentView.element.focus();
                 self.editor.composer.commands.exec("insertImage", url);
             };
 
@@ -258,6 +259,7 @@
             var insertLink = function() {
                 var url = urlInput.val();
                 urlInput.val(initialValue);
+                self.editor.currentView.element.focus();
                 self.editor.composer.commands.exec("createLink", {
                     href: url,
                     target: "_blank",


### PR DESCRIPTION
Small update to fix uncaught exceptions as reported on issue #138

This fix simply gives a focus to the editor's body before executing createLink or insertImage functions.
