### PR TITLE
Feature/allow custom templates

### DIFF
--- a/readme.textile
+++ b/readme.textile
@@ -68,7 +68,7 @@ $('#some-textarea').wysihtml5({
 });
 </pre>
 
-h3. Custom Templates for buttons
+h3. Custom Templates for Toolbar Buttons
 
 To define custom templates for buttons, you can submit a customTemplates hash with the new definitions.  Each entry should be a function which expects 'locale' to manage the translations.
 
@@ -83,22 +83,24 @@ For example, the default template used for the editHtml mode button looks like t
 </pre>
 
 You can change it to not use the pencil icon (for example) by defining the custom template like this:
-<pre>
-     var myCustomTemplates = {
-       html : function(locale) {
-         return "<li>" +
-                "<div class='btn-group'>" +
-                "<a class='btn' data-wysihtml5-action='change_view' title='" + locale.html.edit + "'>HTML</a>" +
-                "</div>" +
-                "</li>";
-       }
-     }
- 
-     // pass in your custom templates on init
-     $('#some-textarea').wysihtml5({
-	customTemplates: myCustomTemplates
-     });
+
+<pre language='javascript'>
+var myCustomTemplates = {
+  html : function(locale) {
+    return "<li>" +
+           "<div class='btn-group'>" +
+           "<a class='btn' data-wysihtml5-action='change_view' title='" + locale.html.edit + "'>HTML</a>" +
+           "</div>" +
+           "</li>";
+  }
+}
+
+// pass in your custom templates on init
+$('#some-textarea').wysihtml5({
+   customTemplates: myCustomTemplates
+});
 </pre>
+
 
 This will override only the toolbar template for html, and all others will use the default.
 

--- a/readme.textile
+++ b/readme.textile
@@ -135,31 +135,6 @@ $(this).wysihtml5('resetDefaults')
 
 Operations on the defaults are not thread-safe; if you're going to change the defaults, you probably want to do it only once, after you load the bootstrap-wysihtml plugin and before you start instantiating your editors.
 
-h3. Custom styles menu
-
-You can add custom styles (which wrap text with spans that have a class) using adding customStyles to your options.
-
-<pre>
-$(this).wysihtml5({customStyles : { my_style: 'My Style' }}) 
-</pre>
-
-will create a new item in the styles dropdown menu which reads "MyStyle".  If you highlight text and choose this style, the text will be wrapped with
-
-<pre>
-<span class="my_style"> the selected text </span>
-</pre>
-
-These custom styles will also be automatically added to the safe-class list in the parser.
-
-You can also remove default styles from this menu by including an array of styles you'd like to not be included.  The default styles are 'h1','h2','h3', and 'normal'.  
-
-<pre>
-$(this).wysihtml5({removeStyles : ['h2', 'h3']})
-</pre>
-
-will give you a styles menu that only includes 'h1' and 'normal'.
-
-
 h2. The underlying wysihtml5 object
 
 You can access the "wysihtml5 editor object":https://github.com/xing/wysihtml5 like this:

--- a/readme.textile
+++ b/readme.textile
@@ -68,6 +68,41 @@ $('#some-textarea').wysihtml5({
 });
 </pre>
 
+h3. Custom Templates for buttons
+
+To define custom templates for buttons, you can submit a customTemplates hash with the new definitions.  Each entry should be a function which expects 'locale' to manage the translations.
+
+For example, the default template used for the editHtml mode button looks like this
+
+<pre>
+<li>
+  <div class='btn-group'>
+    <a class='btn' data-wysihtml5-action='change_view' title='" + locale.html.edit + "'><i class='icon-pencil'></i></a>" 
+  </div>
+</li>
+</pre>
+
+You can change it to not use the pencil icon (for example) by defining the custom template like this:
+<pre>
+     var myCustomTemplates = {
+       html : function(locale) {
+         return "<li>" +
+                "<div class='btn-group'>" +
+                "<a class='btn' data-wysihtml5-action='change_view' title='" + locale.html.edit + "'>HTML</a>" +
+                "</div>" +
+                "</li>";
+       }
+     }
+ 
+     // pass in your custom templates on init
+     $('#some-textarea').wysihtml5({
+	customTemplates: myCustomTemplates
+     });
+</pre>
+
+This will override only the toolbar template for html, and all others will use the default.
+
+
 h3. Stylesheets
 
 It is possible to supply a number of stylesheets for inclusion in the editor `<iframe>`:

--- a/readme.textile
+++ b/readme.textile
@@ -135,6 +135,31 @@ $(this).wysihtml5('resetDefaults')
 
 Operations on the defaults are not thread-safe; if you're going to change the defaults, you probably want to do it only once, after you load the bootstrap-wysihtml plugin and before you start instantiating your editors.
 
+h3. Custom styles menu
+
+You can add custom styles (which wrap text with spans that have a class) using adding customStyles to your options.
+
+<pre>
+$(this).wysihtml5({customStyles : { my_style: 'My Style' }}) 
+</pre>
+
+will create a new item in the styles dropdown menu which reads "MyStyle".  If you highlight text and choose this style, the text will be wrapped with
+
+<pre>
+<span class="my_style"> the selected text </span>
+</pre>
+
+These custom styles will also be automatically added to the safe-class list in the parser.
+
+You can also remove default styles from this menu by including an array of styles you'd like to not be included.  The default styles are 'h1','h2','h3', and 'normal'.  
+
+<pre>
+$(this).wysihtml5({removeStyles : ['h2', 'h3']})
+</pre>
+
+will give you a styles menu that only includes 'h1' and 'normal'.
+
+
 h2. The underlying wysihtml5 object
 
 You can access the "wysihtml5 editor object":https://github.com/xing/wysihtml5 like this:

--- a/src/bootstrap-wysihtml5.js
+++ b/src/bootstrap-wysihtml5.js
@@ -287,7 +287,7 @@
                 var activeButton = $(this).hasClass("wysihtml5-command-active");
 
                 if (!activeButton) {
-                    insertLinkModal.append('body').modal('show');
+                    insertLinkModal.appendTo('body').modal('show');
                     insertLinkModal.on('click.dismiss.modal', '[data-dismiss="modal"]', function(e) {
                         e.stopPropagation();
                     });

--- a/src/bootstrap-wysihtml5.js
+++ b/src/bootstrap-wysihtml5.js
@@ -1,6 +1,20 @@
 !function($, wysi) {
     "use strict";
+     (function(wysi) {
+          var undef;
+          wysi.commands.customSpan = {
+              exec: function(composer, command, sty) {
+                  return wysi.commands.formatInline.exec(composer, 'insertHTML', "span", sty, new RegExp(sty));
+              },
+              state: function(composer, command, sty) {
+                  return wysi.commands.formatInline.state(composer, 'insertHTML', "span", sty, new RegExp(sty));
+              },
 
+              value: function() {
+                  return undef;
+              }
+        };
+    })(wysi);
     var templates = function(key, locale) {
 
         var tpl = {
@@ -18,7 +32,7 @@
                 });
                 locale.font_styles.custom = locale.font_styles.custom || [];
                 $.each(locale.font_styles.custom, function(style, displayName) {
-                    tmpl += "<li><a data-wysihtml5-command='customSpan' data-wsyihtml5-command-value='" + style + "'>" + displayName + "</a></li>";
+                    tmpl += "<li><a data-wysihtml5-command='customSpan' data-wysihtml5-command-value='" + style + "'>" + displayName + "</a></li>";
                 });
                 tmpl += "</ul>" +
                 "</li>";

--- a/src/bootstrap-wysihtml5.js
+++ b/src/bootstrap-wysihtml5.js
@@ -1,111 +1,122 @@
 !function($, wysi) {
     "use strict";
 
+    var tpl = {
+        "font-styles": function(locale) {
+            return "<li class='dropdown'>" +
+              "<a class='btn dropdown-toggle' data-toggle='dropdown' href='#'>" +
+              "<i class='icon-font'></i>&nbsp;<span class='current-font'>" + locale.font_styles.normal + "</span>&nbsp;<b class='caret'></b>" +
+              "</a>" +
+              "<ul class='dropdown-menu'>" +
+                "<li><a data-wysihtml5-command='formatBlock' data-wysihtml5-command-value='div'>" + locale.font_styles.normal + "</a></li>" +
+                "<li><a data-wysihtml5-command='formatBlock' data-wysihtml5-command-value='h1'>" + locale.font_styles.h1 + "</a></li>" +
+                "<li><a data-wysihtml5-command='formatBlock' data-wysihtml5-command-value='h2'>" + locale.font_styles.h2 + "</a></li>" +
+                "<li><a data-wysihtml5-command='formatBlock' data-wysihtml5-command-value='h3'>" + locale.font_styles.h3 + "</a></li>" +
+              "</ul>" +
+            "</li>";
+        },
+
+        "emphasis": function(locale) {
+            return "<li>" +
+              "<div class='btn-group'>" +
+                "<a class='btn' data-wysihtml5-command='bold' title='CTRL+B'>" + locale.emphasis.bold + "</a>" +
+                "<a class='btn' data-wysihtml5-command='italic' title='CTRL+I'>" + locale.emphasis.italic + "</a>" +
+                "<a class='btn' data-wysihtml5-command='underline' title='CTRL+U'>" + locale.emphasis.underline + "</a>" +
+              "</div>" +
+            "</li>";
+        },
+
+        "lists": function(locale) {
+            return "<li>" +
+              "<div class='btn-group'>" +
+                "<a class='btn' data-wysihtml5-command='insertUnorderedList' title='" + locale.lists.unordered + "'><i class='icon-list'></i></a>" +
+                "<a class='btn' data-wysihtml5-command='insertOrderedList' title='" + locale.lists.ordered + "'><i class='icon-th-list'></i></a>" +
+                "<a class='btn' data-wysihtml5-command='Outdent' title='" + locale.lists.outdent + "'><i class='icon-indent-right'></i></a>" +
+                "<a class='btn' data-wysihtml5-command='Indent' title='" + locale.lists.indent + "'><i class='icon-indent-left'></i></a>" +
+              "</div>" +
+            "</li>";
+        },
+
+        "link": function(locale) {
+            return "<li>" +
+              "<div class='bootstrap-wysihtml5-insert-link-modal modal hide fade'>" +
+                "<div class='modal-header'>" +
+                  "<a class='close' data-dismiss='modal'>&times;</a>" +
+                  "<h3>" + locale.link.insert + "</h3>" +
+                "</div>" +
+                "<div class='modal-body'>" +
+                  "<input value='http://' class='bootstrap-wysihtml5-insert-link-url input-xlarge'>" +
+                "</div>" +
+                "<div class='modal-footer'>" +
+                  "<a href='#' class='btn' data-dismiss='modal'>" + locale.link.cancel + "</a>" +
+                  "<a href='#' class='btn btn-primary' data-dismiss='modal'>" + locale.link.insert + "</a>" +
+                "</div>" +
+              "</div>" +
+              "<a class='btn' data-wysihtml5-command='createLink' title='" + locale.link.insert + "'><i class='icon-share'></i></a>" +
+            "</li>";
+        },
+
+        "image": function(locale) {
+            return "<li>" +
+              "<div class='bootstrap-wysihtml5-insert-image-modal modal hide fade'>" +
+                "<div class='modal-header'>" +
+                  "<a class='close' data-dismiss='modal'>&times;</a>" +
+                  "<h3>" + locale.image.insert + "</h3>" +
+                "</div>" +
+                "<div class='modal-body'>" +
+                  "<input value='http://' class='bootstrap-wysihtml5-insert-image-url input-xlarge'>" +
+                "</div>" +
+                "<div class='modal-footer'>" +
+                  "<a href='#' class='btn' data-dismiss='modal'>" + locale.image.cancel + "</a>" +
+                  "<a href='#' class='btn btn-primary' data-dismiss='modal'>" + locale.image.insert + "</a>" +
+                "</div>" +
+              "</div>" +
+              "<a class='btn' data-wysihtml5-command='insertImage' title='" + locale.image.insert + "'><i class='icon-picture'></i></a>" +
+            "</li>";
+        },
+
+        "html": function(locale) {
+            return "<li>" +
+              "<div class='btn-group'>" +
+                "<a class='btn' data-wysihtml5-action='change_view' title='" + locale.html.edit + "'><i class='icon-pencil'></i></a>" +
+              "</div>" +
+            "</li>";
+        },
+
+        "color": function(locale) {
+            return "<li class='dropdown'>" +
+              "<a class='btn dropdown-toggle' data-toggle='dropdown' href='#'>" +
+                "<span class='current-color'>" + locale.colours.black + "</span>&nbsp;<b class='caret'></b>" +
+              "</a>" +
+              "<ul class='dropdown-menu'>" +
+                "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='black'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='black'>" + locale.colours.black + "</a></li>" +
+                "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='silver'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='silver'>" + locale.colours.silver + "</a></li>" +
+                "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='gray'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='gray'>" + locale.colours.gray + "</a></li>" +
+                "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='maroon'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='maroon'>" + locale.colours.maroon + "</a></li>" +
+                "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='red'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='red'>" + locale.colours.red + "</a></li>" +
+                "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='purple'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='purple'>" + locale.colours.purple + "</a></li>" +
+                "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='green'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='green'>" + locale.colours.green + "</a></li>" +
+                "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='olive'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='olive'>" + locale.colours.olive + "</a></li>" +
+                "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='navy'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='navy'>" + locale.colours.navy + "</a></li>" +
+                "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='blue'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='blue'>" + locale.colours.blue + "</a></li>" +
+                "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='orange'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='orange'>" + locale.colours.orange + "</a></li>" +
+              "</ul>" +
+            "</li>";
+        }
+    };
+
     var templates = function(key, locale) {
-
-        var tpl = {
-            "font-styles":
-                "<li class='dropdown'>" +
-                  "<a class='btn dropdown-toggle' data-toggle='dropdown' href='#'>" +
-                  "<i class='icon-font'></i>&nbsp;<span class='current-font'>" + locale.font_styles.normal + "</span>&nbsp;<b class='caret'></b>" +
-                  "</a>" +
-                  "<ul class='dropdown-menu'>" +
-                    "<li><a data-wysihtml5-command='formatBlock' data-wysihtml5-command-value='div'>" + locale.font_styles.normal + "</a></li>" +
-                    "<li><a data-wysihtml5-command='formatBlock' data-wysihtml5-command-value='h1'>" + locale.font_styles.h1 + "</a></li>" +
-                    "<li><a data-wysihtml5-command='formatBlock' data-wysihtml5-command-value='h2'>" + locale.font_styles.h2 + "</a></li>" +
-                    "<li><a data-wysihtml5-command='formatBlock' data-wysihtml5-command-value='h3'>" + locale.font_styles.h3 + "</a></li>" +
-                  "</ul>" +
-                "</li>",
-
-            "emphasis":
-                "<li>" +
-                  "<div class='btn-group'>" +
-                    "<a class='btn' data-wysihtml5-command='bold' title='CTRL+B'>" + locale.emphasis.bold + "</a>" +
-                    "<a class='btn' data-wysihtml5-command='italic' title='CTRL+I'>" + locale.emphasis.italic + "</a>" +
-                    "<a class='btn' data-wysihtml5-command='underline' title='CTRL+U'>" + locale.emphasis.underline + "</a>" +
-                  "</div>" +
-                "</li>",
-
-            "lists":
-                "<li>" +
-                  "<div class='btn-group'>" +
-                    "<a class='btn' data-wysihtml5-command='insertUnorderedList' title='" + locale.lists.unordered + "'><i class='icon-list'></i></a>" +
-                    "<a class='btn' data-wysihtml5-command='insertOrderedList' title='" + locale.lists.ordered + "'><i class='icon-th-list'></i></a>" +
-                    "<a class='btn' data-wysihtml5-command='Outdent' title='" + locale.lists.outdent + "'><i class='icon-indent-right'></i></a>" +
-                    "<a class='btn' data-wysihtml5-command='Indent' title='" + locale.lists.indent + "'><i class='icon-indent-left'></i></a>" +
-                  "</div>" +
-                "</li>",
-
-            "link":
-                "<li>" +
-                  "<div class='bootstrap-wysihtml5-insert-link-modal modal hide fade'>" +
-                    "<div class='modal-header'>" +
-                      "<a class='close' data-dismiss='modal'>&times;</a>" +
-                      "<h3>" + locale.link.insert + "</h3>" +
-                    "</div>" +
-                    "<div class='modal-body'>" +
-                      "<input value='http://' class='bootstrap-wysihtml5-insert-link-url input-xlarge'>" +
-                    "</div>" +
-                    "<div class='modal-footer'>" +
-                      "<a href='#' class='btn' data-dismiss='modal'>" + locale.link.cancel + "</a>" +
-                      "<a href='#' class='btn btn-primary' data-dismiss='modal'>" + locale.link.insert + "</a>" +
-                    "</div>" +
-                  "</div>" +
-                  "<a class='btn' data-wysihtml5-command='createLink' title='" + locale.link.insert + "'><i class='icon-share'></i></a>" +
-                "</li>",
-
-            "image":
-                "<li>" +
-                  "<div class='bootstrap-wysihtml5-insert-image-modal modal hide fade'>" +
-                    "<div class='modal-header'>" +
-                      "<a class='close' data-dismiss='modal'>&times;</a>" +
-                      "<h3>" + locale.image.insert + "</h3>" +
-                    "</div>" +
-                    "<div class='modal-body'>" +
-                      "<input value='http://' class='bootstrap-wysihtml5-insert-image-url input-xlarge'>" +
-                    "</div>" +
-                    "<div class='modal-footer'>" +
-                      "<a href='#' class='btn' data-dismiss='modal'>" + locale.image.cancel + "</a>" +
-                      "<a href='#' class='btn btn-primary' data-dismiss='modal'>" + locale.image.insert + "</a>" +
-                    "</div>" +
-                  "</div>" +
-                  "<a class='btn' data-wysihtml5-command='insertImage' title='" + locale.image.insert + "'><i class='icon-picture'></i></a>" +
-                "</li>",
-
-            "html":
-                "<li>" +
-                  "<div class='btn-group'>" +
-                    "<a class='btn' data-wysihtml5-action='change_view' title='" + locale.html.edit + "'><i class='icon-pencil'></i></a>" +
-                  "</div>" +
-                "</li>",
-
-            "color":
-                "<li class='dropdown'>" +
-                  "<a class='btn dropdown-toggle' data-toggle='dropdown' href='#'>" +
-                    "<span class='current-color'>" + locale.colours.black + "</span>&nbsp;<b class='caret'></b>" +
-                  "</a>" +
-                  "<ul class='dropdown-menu'>" +
-                    "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='black'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='black'>" + locale.colours.black + "</a></li>" +
-                    "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='silver'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='silver'>" + locale.colours.silver + "</a></li>" +
-                    "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='gray'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='gray'>" + locale.colours.gray + "</a></li>" +
-                    "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='maroon'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='maroon'>" + locale.colours.maroon + "</a></li>" +
-                    "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='red'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='red'>" + locale.colours.red + "</a></li>" +
-                    "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='purple'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='purple'>" + locale.colours.purple + "</a></li>" +
-                    "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='green'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='green'>" + locale.colours.green + "</a></li>" +
-                    "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='olive'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='olive'>" + locale.colours.olive + "</a></li>" +
-                    "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='navy'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='navy'>" + locale.colours.navy + "</a></li>" +
-                    "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='blue'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='blue'>" + locale.colours.blue + "</a></li>" +
-                    "<li><div class='wysihtml5-colors' data-wysihtml5-command-value='orange'></div><a class='wysihtml5-colors-title' data-wysihtml5-command='foreColor' data-wysihtml5-command-value='orange'>" + locale.colours.orange + "</a></li>" +
-                  "</ul>" +
-                "</li>"
-        };
-        return tpl[key];
+        return tpl[key](locale);
     };
 
 
     var Wysihtml5 = function(el, options) {
         this.el = el;
-        this.toolbar = this.createToolbar(el, options || defaultOptions);
+        var toolbarOpts = options || defaultOptions;
+        for(var t in toolbarOpts.customTemplates) {
+          tpl[t] = toolbarOpts.customTemplates[t];
+        }
+        this.toolbar = this.createToolbar(el, toolbarOpts);
         this.editor =  this.createEditor(options);
 
         window.editor = this.editor;

--- a/src/bootstrap-wysihtml5.js
+++ b/src/bootstrap-wysihtml5.js
@@ -1,20 +1,6 @@
 !function($, wysi) {
     "use strict";
-     (function(wysi) {
-          var undef;
-          wysi.commands.customSpan = {
-              exec: function(composer, command, sty) {
-                  return wysi.commands.formatInline.exec(composer, 'insertHTML', "span", sty, new RegExp(sty));
-              },
-              state: function(composer, command, sty) {
-                  return wysi.commands.formatInline.state(composer, 'insertHTML', "span", sty, new RegExp(sty));
-              },
 
-              value: function() {
-                  return undef;
-              }
-        };
-    })(wysi);
     var templates = function(key, locale) {
 
         var tpl = {
@@ -32,7 +18,7 @@
                 });
                 locale.font_styles.custom = locale.font_styles.custom || [];
                 $.each(locale.font_styles.custom, function(style, displayName) {
-                    tmpl += "<li><a data-wysihtml5-command='customSpan' data-wysihtml5-command-value='" + style + "'>" + displayName + "</a></li>";
+                    tmpl += "<li><a data-wysihtml5-command='customSpan' data-wsyihtml5-command-value='" + style + "'>" + displayName + "</a></li>";
                 });
                 tmpl += "</ul>" +
                 "</li>";

--- a/src/bootstrap-wysihtml5.js
+++ b/src/bootstrap-wysihtml5.js
@@ -4,26 +4,19 @@
     var templates = function(key, locale) {
 
         var tpl = {
-            "font-styles": (function() {
-                var tmpl = "<li class='dropdown'>" +
-                    "<a class='btn dropdown-toggle' data-toggle='dropdown' href='#'>" +
-                    "<i class='icon-font'></i>&nbsp;<span class='current-font'>" + locale.font_styles.normal + "</span>&nbsp;<b class='caret'></b>" +
-                    "</a>" +
-                    "<ul class='dropdown-menu'>";
-                var stylesToRemove = locale.font_styles.remove || [];
-                $.each(['normal','h1','h2','h3'], function(idx, key) {
-                     if (stylesToRemove.indexOf(key) < 0) {
-                       tmpl += "<li><a data-wysihtml5-command='formatBlock' data-wysihtml5-command-value='" + key + "'>" + locale.font_styles[key] + "</a></li>";
-                     }
-                });
-                locale.font_styles.custom = locale.font_styles.custom || [];
-                $.each(locale.font_styles.custom, function(style, displayName) {
-                    tmpl += "<li><a data-wysihtml5-command='customSpan' data-wsyihtml5-command-value='" + style + "'>" + displayName + "</a></li>";
-                });
-                tmpl += "</ul>" +
-                "</li>";
-                return tmpl;
-            })(),
+            "font-styles":
+                "<li class='dropdown'>" +
+                  "<a class='btn dropdown-toggle' data-toggle='dropdown' href='#'>" +
+                  "<i class='icon-font'></i>&nbsp;<span class='current-font'>" + locale.font_styles.normal + "</span>&nbsp;<b class='caret'></b>" +
+                  "</a>" +
+                  "<ul class='dropdown-menu'>" +
+                    "<li><a data-wysihtml5-command='formatBlock' data-wysihtml5-command-value='div'>" + locale.font_styles.normal + "</a></li>" +
+                    "<li><a data-wysihtml5-command='formatBlock' data-wysihtml5-command-value='h1'>" + locale.font_styles.h1 + "</a></li>" +
+                    "<li><a data-wysihtml5-command='formatBlock' data-wysihtml5-command-value='h2'>" + locale.font_styles.h2 + "</a></li>" +
+                    "<li><a data-wysihtml5-command='formatBlock' data-wysihtml5-command-value='h3'>" + locale.font_styles.h3 + "</a></li>" +
+                  "</ul>" +
+                "</li>",
+
             "emphasis":
                 "<li>" +
                   "<div class='btn-group'>" +
@@ -112,13 +105,7 @@
 
     var Wysihtml5 = function(el, options) {
         this.el = el;
-        var toolbarOpts = options || defaultOptions
-        // add custom classes to the save class list */
-        for(var k in toolbarOpts.customStyles) {
-            toolbarOpts.parserRules.classes[k] = 1;
-        }
-        this.configuration = toolbarOpts;
-        this.toolbar = this.createToolbar(el, toolbarOpts);
+        this.toolbar = this.createToolbar(el, options || defaultOptions);
         this.editor =  this.createEditor(options);
 
         window.editor = this.editor;
@@ -157,8 +144,6 @@
                 'style': "display:none"
             });
             var culture = options.locale || defaultOptions.locale || "en";
-            locale[culture].font_styles.custom = options.customStyles;
-            locale[culture].font_styles.remove = options.removeStyles;
             for(var key in defaultOptions) {
                 var value = false;
 
@@ -363,8 +348,6 @@
         "link": true,
         "image": true,
         events: {},
-        customStyles: {},
-        removeStyles: [],
         parserRules: {
             classes: {
                 // (path_to_project/lib/css/wysiwyg-color.css)

--- a/test/editor_test.js
+++ b/test/editor_test.js
@@ -36,13 +36,10 @@ if (wysihtml5.browser.supported()) {
     getComposerElement: function() {
       return this.getIframeElement().contentWindow.document.body;
     },
+
     getIframeElement: function() {
       var iframes = document.querySelectorAll("iframe.wysihtml5-sandbox");
       return iframes[iframes.length - 1];
-    },
-    getToolbarElement: function() {
-      var toolbars = document.querySelectorAll(".wysihtml5-toolbar");
-      return toolbars[0];
     }
   });
 
@@ -116,27 +113,6 @@ if (wysihtml5.browser.supported()) {
       ok(wysihtml5.dom.hasClass(composerElement, name), "iFrame's body has adopted name as className");
       ok(wysihtml5.dom.hasClass(composerElement, "death-star"), "iFrame's body has adopted the textarea className");
       ok(!wysihtml5.dom.hasClass(textareaElement, name), "Textarea has not adopted name as className");
-      start();
-    });
-  });
-
-
-  asyncTest("Check the toolbar and customStyles", function() {
-    expect(4);
-
-    this.textareaElement.className = "death-star";
-
-    var that   = this;
-    var name   = "star-wars-input";
-    $(this.textareaElement).wysihtml5({ html: true, customStyles: { other: 'Other Style'}, removeStyles: [ 'h1' ] });
-    var editor = $(this.textareaElement).data('wysihtml5').editor;
-    var classes = $(this.textareaElement).data('wysihtml5').configuration.parserRules.classes
-    ok(classes.other === 1, 'custom classes were not added to the safe parse list');
-    editor.observe("load", function() {
-      var toolbar = that.getToolbarElement();
-      ok($(toolbar).find('ul.dropdown-menu a[data-wysihtml5-command=formatBlock]').length === 3, "toolbar includes all default styles that were not removed witgh removeStyles option");
-      ok($(toolbar).find('ul.dropdown-menu a[data-wysihtml5-command=customSpan]').length === 1 , "toolbar includes the custom styles");
-      ok(/Other Style/.test($(toolbar).find('ul.dropdown-menu a[data-wysihtml5-command=customSpan]').text()), "toolbar custom style title is not correct");
       start();
     });
   });

--- a/test/editor_test.js
+++ b/test/editor_test.js
@@ -36,10 +36,13 @@ if (wysihtml5.browser.supported()) {
     getComposerElement: function() {
       return this.getIframeElement().contentWindow.document.body;
     },
-
     getIframeElement: function() {
       var iframes = document.querySelectorAll("iframe.wysihtml5-sandbox");
       return iframes[iframes.length - 1];
+    },
+    getToolbarElement: function() {
+      var toolbars = document.querySelectorAll(".wysihtml5-toolbar");
+      return toolbars[0];
     }
   });
 
@@ -113,6 +116,27 @@ if (wysihtml5.browser.supported()) {
       ok(wysihtml5.dom.hasClass(composerElement, name), "iFrame's body has adopted name as className");
       ok(wysihtml5.dom.hasClass(composerElement, "death-star"), "iFrame's body has adopted the textarea className");
       ok(!wysihtml5.dom.hasClass(textareaElement, name), "Textarea has not adopted name as className");
+      start();
+    });
+  });
+
+
+  asyncTest("Check the toolbar and customStyles", function() {
+    expect(4);
+
+    this.textareaElement.className = "death-star";
+
+    var that   = this;
+    var name   = "star-wars-input";
+    $(this.textareaElement).wysihtml5({ html: true, customStyles: { other: 'Other Style'}, removeStyles: [ 'h1' ] });
+    var editor = $(this.textareaElement).data('wysihtml5').editor;
+    var classes = $(this.textareaElement).data('wysihtml5').configuration.parserRules.classes
+    ok(classes.other === 1, 'custom classes were not added to the safe parse list');
+    editor.observe("load", function() {
+      var toolbar = that.getToolbarElement();
+      ok($(toolbar).find('ul.dropdown-menu a[data-wysihtml5-command=formatBlock]').length === 3, "toolbar includes all default styles that were not removed witgh removeStyles option");
+      ok($(toolbar).find('ul.dropdown-menu a[data-wysihtml5-command=customSpan]').length === 1 , "toolbar includes the custom styles");
+      ok(/Other Style/.test($(toolbar).find('ul.dropdown-menu a[data-wysihtml5-command=customSpan]').text()), "toolbar custom style title is not correct");
       start();
     });
   });

--- a/test/editor_test.js
+++ b/test/editor_test.js
@@ -149,6 +149,34 @@ if (wysihtml5.browser.supported()) {
   });
 
 
+  asyncTest('Check whether customTemplates work', function() {
+    expect(3);
+
+    $(this.textareaElement).wysihtml5({
+      html: true,
+      customTemplates:
+      {
+        image: function(locale) { 
+          return '<div class="custom_image">' + locale.image.insert + '</div>';
+        },
+        html: function(locale) {
+           return "<li>" +
+                  "<div class='btn-group html-edit-button'>" +
+                  "<a class='btn' data-wysihtml5-action='change_view' title='" + locale.html.edit + "'>HTML</a>" +
+                  "</div>" +
+                  "</li>";
+       }
+      }
+    });
+    editor.observe("load", function() {
+      equal($('form .wysihtml5-toolbar').length, 1, 'Toolbar is showing')
+      equal($('form .wysihtml5-toolbar .custom_image').length, 1, 'Custom image template works')
+      equal($('form .wysihtml5-toolbar li .html-edit-button a').html(), 'HTML', 'Custom html template works')
+      start();
+    });
+  });
+
+
   asyncTest("Check whether attributes are copied", function() {
     expect(1);
 


### PR DESCRIPTION
Allow customization of toolbar templates.

This is basically so that if i want a custom modal, or a custom image insert dialog, I can override the templates that draw the toolbar.

The basic change is that the templates become functions that take locale, instead of simple strings.  And then with options.customTemplates, you can override the default functions.

I've added to the readme to explain how to use it and added tests.

You may notice a bunch of commits.  The last two are the important ones, the first 8 are me trying to get my fork to match your current master branch.

Cheers
Mr Rogers
