### PR TITLE
Fix docu get editor

### DIFF
--- a/readme.textile
+++ b/readme.textile
@@ -177,7 +177,7 @@ h2. The underlying wysihtml5 object
 You can access the "wysihtml5 editor object":https://github.com/xing/wysihtml5 like this:
 
 <pre>
-var wysihtml5Editor = $('#some-textarea').wysihtml5().data("wysihtml5").editor;
+var wysihtml5Editor = $('#some-textarea').data("wysihtml5").editor;
 wysihtml5Editor.composer.commands.exec("bold");
 </pre>
 

--- a/src/locales/bootstrap-wysihtml5.bg-BG.js
+++ b/src/locales/bootstrap-wysihtml5.bg-BG.js
@@ -1,0 +1,49 @@
+/**
+ * Bulgarian translation for bootstrap-wysihtml5
+ */
+(function($){
+    $.fn.wysihtml5.locale["bg-BG"] = {
+        font_styles: {
+            normal: "Нормален текст",
+            h1: "Заглавие 1",
+            h2: "Заглавие 2",
+            h3: "Заглавие 3"
+        },
+        emphasis: {
+            bold: "Удебелен",
+            italic: "Курсив",
+            underline: "Подчертан"
+        },
+        lists: {
+            unordered: "Неподреден списък",
+            ordered: "Подреден списък",
+            outdent: "Намали отстояние",
+            indent: "Увеличи отстояние"
+        },
+        link: {
+            insert: "Вмъкни връзка",
+            cancel: "Отмени"
+        },
+        image: {
+            insert: "Вмъкни картинка",
+            cancel: "Отмени"
+        },
+        html: {
+            edit: "Редакртирай HTML"
+        },
+        colours: {
+            black: "Черен",
+            silver: "Сребърен",
+            gray: "Сив",
+            maroon: "Коричневый",
+            red: "Червен",
+            purple: "Виолетов",
+            green: "Зелен",
+            olive: "Маслинен",
+            navy: "Морско син",
+            blue: "Син",
+            orange: "Оранжев"
+        }
+    };
+}(jQuery));
+


### PR DESCRIPTION
There is a small error in the README documentation.
To get the editor instance one should use the textarea's data directly without calling .wysihtml5() on it.
