### PR TITLE
Image modal; append to `body` as well as link modal

### DIFF
--- a/src/bootstrap-wysihtml5.js
+++ b/src/bootstrap-wysihtml5.js
@@ -262,7 +262,7 @@
                 if (!activeButton) {
                     self.editor.currentView.element.focus(false);
                     caretBookmark = self.editor.composer.selection.getBookmark();
-                    insertImageModal.modal('show');
+                    insertImageModal.appendTo('body').modal('show');
                     insertImageModal.on('click.dismiss.modal', '[data-dismiss="modal"]', function(e) {
                         e.stopPropagation();
                     });


### PR DESCRIPTION
i'm using wysihtml5 inside popover. Image modal works incorrect although link modal is ok. I found that in showing method for image there is no `appendTo('body')`.
When I add it image works fine.
