### PR TITLE
Fixing issue with multiple instances on a page

### DIFF
--- a/src/bootstrap-wysihtml5.js
+++ b/src/bootstrap-wysihtml5.js
@@ -143,6 +143,10 @@
 
         createEditor: function(options) {
             options = options || {};
+            
+            // Add the toolbar to a clone of the options object so multiple instances
+            // of the WYISYWG don't break because "toolbar" is already defined
+            options = $.extend(true, {}, options);
             options.toolbar = this.toolbar[0];
 
             var editor = new wysi.Editor(this.el[0], options);


### PR DESCRIPTION
I was getting a "Uncaught Error: NOT_FOUND_ERR: DOM Exception 8 for appendChild call" error when I had multiple textareas with WYSIWYGs on the same page.  It was because, for the second instance, the options.toolbar was defined for the `createToolbar()` because of how it gets added into the `options` object in `createEditor()` before being passed to `new wysi.Editor`.

This fix clones the options object before adding the toolbar.
