### PR TITLE
Fix in bypassDefaults. If $.fn.wysihtml5 is invoked for more than 1 text...

### DIFF
--- a/src/bootstrap-wysihtml5.js
+++ b/src/bootstrap-wysihtml5.js
@@ -353,7 +353,7 @@
         bypassDefaults: function(options) {
             return this.each(function () {
                 var $this = $(this);
-                $this.data('wysihtml5', new Wysihtml5($this, options));
+                $this.data('wysihtml5', new Wysihtml5($this, $.extend({},options}));
             });
         },
         shallowExtend: function (options) {


### PR DESCRIPTION
...area

(in jQuery 2.0) doesnt work. The instances of wysihtml5 can't share the same options object.
