### PR TITLE
Inverts identation icons (which where wrong)

### DIFF
--- a/src/bootstrap-wysihtml5.js
+++ b/src/bootstrap-wysihtml5.js
@@ -37,8 +37,8 @@
               "<div class='btn-group'>" +
                 "<a class='btn" + size + "' data-wysihtml5-command='insertUnorderedList' title='" + locale.lists.unordered + "' tabindex='-1'><i class='icon-list'></i></a>" +
                 "<a class='btn" + size + "' data-wysihtml5-command='insertOrderedList' title='" + locale.lists.ordered + "' tabindex='-1'><i class='icon-th-list'></i></a>" +
-                "<a class='btn" + size + "' data-wysihtml5-command='Outdent' title='" + locale.lists.outdent + "' tabindex='-1'><i class='icon-indent-right'></i></a>" +
-                "<a class='btn" + size + "' data-wysihtml5-command='Indent' title='" + locale.lists.indent + "' tabindex='-1'><i class='icon-indent-left'></i></a>" +
+                "<a class='btn" + size + "' data-wysihtml5-command='Outdent' title='" + locale.lists.outdent + "' tabindex='-1'><i class='icon-indent-left'></i></a>" +
+                "<a class='btn" + size + "' data-wysihtml5-command='Indent' title='" + locale.lists.indent + "' tabindex='-1'><i class='icon-indent-right'></i></a>" +
               "</div>" +
             "</li>";
         },


### PR DESCRIPTION
Actually the "outdent" button uses icon-indent-right, which clearly represents an action of pushing the text to the right side. The same goes with the "ident" button that has an icon representing the opposite action.
If you check the [official demo of bootstrap-wysihtml5](http://jhollingworth.github.io/bootstrap-wysihtml5/) you'll see that the buttons are correct.
