### PR TITLE
Update bootstrap-wysihtml5.pt-BR.js

### DIFF
--- a/src/locales/bootstrap-wysihtml5.pt-BR.js
+++ b/src/locales/bootstrap-wysihtml5.pt-BR.js
@@ -20,8 +20,8 @@
         lists: {
             unordered: "Lista",
             ordered: "Lista numerada",
-            outdent: "Remover indentação",
-            indent: "Indentar"
+            outdent: "Diminuir recuo",
+            indent: "Aumentar recuo"
         },
         link: {
             insert: "Inserir link",


### PR DESCRIPTION
In Portuguese verb "indentar" does not exist.
