### PR TITLE
Fix textile formatting so it is displayed in github readme

### DIFF
--- a/readme.textile
+++ b/readme.textile
@@ -109,9 +109,9 @@ This will override only the toolbar template for html, and all others will use t
 
 h3. Stylesheets
 
-It is possible to supply a number of stylesheets for inclusion in the editor `<iframe>`:
+It is possible to supply a number of stylesheets for inclusion in the editor `&lt;iframe&gt;`:
 
-<pre>
+<pre language='javascript'>
 $('#some-textarea').wysihtml5({
 	"stylesheets": ["/path/to/editor.css"]
 });
@@ -121,7 +121,7 @@ h3. Events
 
 Wysihtml5 exposes a "number of events":https://github.com/xing/wysihtml5/wiki/Events. You can hook into these events when initialising the editor:
 
-<pre>
+<pre language='javascript'>
 $('#some-textarea').wysihtml5({
 	"events": {
 		"load": function() { 
@@ -182,7 +182,6 @@ You can access the "wysihtml5 editor object":https://github.com/xing/wysihtml5 l
 var wysihtml5Editor = $('#some-textarea').data("wysihtml5").editor;
 wysihtml5Editor.composer.commands.exec("bold");
 </pre>
-
 
 h2. I18n
 


### PR DESCRIPTION
Line "It is possible to supply a number of stylesheets for inclusion in the editor `<iframe>`:"
includes an html tag not in a <pre> element so I have converted the < and > to html entities
